### PR TITLE
Add support for ECS Scheduled Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ services: # A map of services
   <service-name>: # The name of the ECS service
     cluster: string # The ECS cluster the service is in
     url: string # The URL to use to check that the new version has been deployed
+scheduledTasks: # A map of ECS scheduled tasks
+  <scheduled-task-name>: # The name of the ECS scheduled task
 ```
 
 An example config is provided in [gehen.example.yml](gehen.example.yml).

--- a/awsecs/awsecs.go
+++ b/awsecs/awsecs.go
@@ -37,75 +37,26 @@ func Deploy(service *config.Service, ecsClient ecsiface.ECSAPI) error {
 		return errors.Wrapf(err, "failed to find service: %s", service.Name)
 	}
 
-	taskDefID := *respDescribeServices.Services[0].TaskDefinition
-	log.Printf("Found current task definition: %+v\n", taskDefID)
+	taskDefARN := *respDescribeServices.Services[0].TaskDefinition
+	log.Printf("Found current task definition: %v\n", taskDefARN)
 
-	// Use resolved service info to grab existing task def
-	respDescribeTaskDef, err := ecsClient.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
-		TaskDefinition: &taskDefID,
-	})
+	updateTaskDefRes, err := updateTaskDef(taskDefARN, service.Gitsha, ecsClient)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get task definition for service: %s", service.Name)
+		return errors.Wrapf(err, "failed to update task def for service: %s", service.Name)
 	}
 
-	// Convert API output to be ready to update task.
-	taskDef := respDescribeTaskDef.TaskDefinition
-	newTaskInput := ecs.RegisterTaskDefinitionInput{
-		ContainerDefinitions:    taskDef.ContainerDefinitions,
-		Cpu:                     taskDef.Cpu,
-		ExecutionRoleArn:        taskDef.ExecutionRoleArn,
-		Family:                  taskDef.Family,
-		IpcMode:                 taskDef.IpcMode,
-		Memory:                  taskDef.Memory,
-		NetworkMode:             taskDef.NetworkMode,
-		PidMode:                 taskDef.PidMode,
-		PlacementConstraints:    taskDef.PlacementConstraints,
-		ProxyConfiguration:      taskDef.ProxyConfiguration,
-		RequiresCompatibilities: taskDef.RequiresCompatibilities,
-		TaskRoleArn:             taskDef.TaskRoleArn,
-		Volumes:                 taskDef.Volumes,
-	}
-
-	previousGitsha := ""
-
-	// Update each container in task def to use same repo with new tag/sha
-	for i, container := range newTaskInput.ContainerDefinitions {
-		// Images have the form <repo-url>/<image>:<tag>
-		t := strings.Split(*container.Image, ":")
-
-		if previousGitsha == "" {
-			// Tag is the last element which is the SHA
-			previousGitsha = t[len(t)-1]
-		}
-
-		// Get new image by using new SHA
-		newImage := fmt.Sprintf("%s:%s", strings.Join(t[:len(t)-1], ""), service.Gitsha)
-		log.Printf("Changing container image %s to %s", color.Cyan(*container.Image), color.Cyan(newImage))
-		*newTaskInput.ContainerDefinitions[i].Image = newImage
-	}
-
-	dockerTags := newTaskInput.ContainerDefinitions[0].DockerLabels
-	tags := make([]string, 0, len(dockerTags))
-	for tag, value := range dockerTags {
-		newTag := fmt.Sprintf("%s:%s", tag, *value)
-		tags = append(tags, newTag)
-	}
-
-	// Create new task def so we can update service to use it
-	respRegisterTaskDef, err := ecsClient.RegisterTaskDefinition(&newTaskInput)
-	if err != nil {
-		return errors.Wrap(err, "cannot register new task definition: ")
-	}
-
-	newTaskArn := *respRegisterTaskDef.TaskDefinition.TaskDefinitionArn
-	log.Printf("Registered new task definition %s, updating service %s\n", color.Cyan(newTaskArn), color.Cyan(service.Name))
+	log.Printf(
+		"Registered new task definition %s, updating service %s\n",
+		color.Cyan(updateTaskDefRes.newTaskDefARN),
+		color.Cyan(service.Name),
+	)
 
 	// Set dynamic service values
 	// Save previous Git SHA in case we need to rollback later
-	service.PreviousGitsha = previousGitsha
-	service.PreviousTaskDefinitionARN = *taskDef.TaskDefinitionArn
-	service.TaskDefinitionARN = newTaskArn
-	service.Tags = tags
+	service.PreviousGitsha = updateTaskDefRes.previousGitsha
+	service.PreviousTaskDefinitionARN = updateTaskDefRes.previousTaskDefARN
+	service.TaskDefinitionARN = updateTaskDefRes.newTaskDefARN
+	service.Tags = updateTaskDefRes.dockerTags
 
 	err = UpdateService(service, ecsClient)
 	if err != nil {
@@ -153,4 +104,79 @@ func CheckDrain(service *config.Service, ecsClient ecsiface.ECSAPI) (bool, error
 	}
 
 	return false, nil
+}
+
+type updateTaskDefResult struct {
+	previousTaskDefARN string
+	newTaskDefARN      string
+	previousGitsha     string
+	dockerTags         []string
+}
+
+// updateTaskDef creates a new task def revision with the container image updated to use the new Git SHA.
+// It returns the new ARN and previous Git SHA.
+func updateTaskDef(taskDefARN, gitsha string, ecsClient ecsiface.ECSAPI) (updateTaskDefResult, error) {
+	// Use resolved resource info to grab existing task def
+	respDescribeTaskDef, err := ecsClient.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: &taskDefARN,
+	})
+	if err != nil {
+		return updateTaskDefResult{}, errors.Wrapf(err, "failed to get task definition: %s", taskDefARN)
+	}
+
+	// Convert API output to be ready to update task.
+	taskDef := respDescribeTaskDef.TaskDefinition
+	newTaskInput := ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions:    taskDef.ContainerDefinitions,
+		Cpu:                     taskDef.Cpu,
+		ExecutionRoleArn:        taskDef.ExecutionRoleArn,
+		Family:                  taskDef.Family,
+		IpcMode:                 taskDef.IpcMode,
+		Memory:                  taskDef.Memory,
+		NetworkMode:             taskDef.NetworkMode,
+		PidMode:                 taskDef.PidMode,
+		PlacementConstraints:    taskDef.PlacementConstraints,
+		ProxyConfiguration:      taskDef.ProxyConfiguration,
+		RequiresCompatibilities: taskDef.RequiresCompatibilities,
+		TaskRoleArn:             taskDef.TaskRoleArn,
+		Volumes:                 taskDef.Volumes,
+	}
+
+	previousGitsha := ""
+
+	// Update each container in task def to use same repo with new tag/sha
+	for i, container := range newTaskInput.ContainerDefinitions {
+		// Images have the form <repo-url>/<image>:<tag>
+		t := strings.Split(*container.Image, ":")
+
+		if previousGitsha == "" {
+			// Tag is the last element which is the SHA
+			previousGitsha = t[len(t)-1]
+		}
+
+		// Get new image by using new SHA
+		newImage := fmt.Sprintf("%s:%s", strings.Join(t[:len(t)-1], ""), gitsha)
+		log.Printf("Changing container image %s to %s", color.Cyan(*container.Image), color.Cyan(newImage))
+		*newTaskInput.ContainerDefinitions[i].Image = newImage
+	}
+
+	dockerTags := newTaskInput.ContainerDefinitions[0].DockerLabels
+	tags := make([]string, 0, len(dockerTags))
+	for tag, value := range dockerTags {
+		newTag := fmt.Sprintf("%s:%s", tag, *value)
+		tags = append(tags, newTag)
+	}
+
+	// Create new task def so we can update service to use it
+	respRegisterTaskDef, err := ecsClient.RegisterTaskDefinition(&newTaskInput)
+	if err != nil {
+		return updateTaskDefResult{}, errors.Wrapf(err, "cannot register new task definition for %s", *newTaskInput.Family)
+	}
+
+	return updateTaskDefResult{
+		previousTaskDefARN: *taskDef.TaskDefinitionArn,
+		newTaskDefARN:      *respRegisterTaskDef.TaskDefinition.TaskDefinitionArn,
+		previousGitsha:     previousGitsha,
+		dockerTags:         tags,
+	}, nil
 }

--- a/awsecs/awsevent.go
+++ b/awsecs/awsevent.go
@@ -1,0 +1,86 @@
+package awsecs
+
+import (
+	"log"
+
+	"github.com/TouchBistro/gehen/config"
+	"github.com/TouchBistro/goutils/color"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface"
+	"github.com/pkg/errors"
+)
+
+type UpdateScheduledTaskArgs struct {
+	Task       *config.ScheduledTask
+	IsRollback bool
+	EBClient   eventbridgeiface.EventBridgeAPI
+	ECSClient  ecsiface.ECSAPI
+}
+
+func UpdateScheduledTask(args UpdateScheduledTaskArgs) error {
+	task := args.Task
+	// Retrieve targets for schedule task eventbridge rule
+	// This will contain the ECS information like the task def
+	respListTargets, err := args.EBClient.ListTargetsByRule(&eventbridge.ListTargetsByRuleInput{
+		Rule: &task.Name,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find eventbridge rule for scheduled task %s", task.Name)
+	}
+
+	// There should only be 1 target if it was created in ECS. If it was created in
+	// event bridge this might need to be modified to be more flexible.
+	if len(respListTargets.Targets) != 1 {
+		return errors.Wrapf(err, "expected 1 target for scheduled task rule, found %d", len(respListTargets.Targets))
+	}
+
+	awsTarget := respListTargets.Targets[0]
+
+	var newTaskDefARN string
+	if args.IsRollback {
+		// If rollback just use the previous task def
+		newTaskDefARN = task.PreviousTaskDefinitionARN
+	} else {
+		// Create a new revision of the task def using the new git sha
+		taskDefARN := *awsTarget.EcsParameters.TaskDefinitionArn
+		log.Printf("Found current task definition: %s\n", taskDefARN)
+		updateTaskDefRes, err := updateTaskDef(taskDefARN, task.Gitsha, args.ECSClient)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update task def for scheduled task: %s", task.Name)
+		}
+
+		log.Printf(
+			"Registered new task definition %s, updating scheduled task %s\n",
+			color.Cyan(updateTaskDefRes.newTaskDefARN),
+			color.Cyan(task.Name),
+		)
+		newTaskDefARN = updateTaskDefRes.newTaskDefARN
+
+		// Set dynamic task values
+		task.PreviousGitsha = updateTaskDefRes.previousGitsha
+		task.PreviousTaskDefinitionARN = updateTaskDefRes.previousTaskDefARN
+		task.TaskDefinitionARN = updateTaskDefRes.newTaskDefARN
+	}
+
+	// Just update the Task Def and use the same target
+	// This way we can make sure all the other config is preserved
+	awsTarget.EcsParameters.TaskDefinitionArn = &newTaskDefARN
+	respPutTargets, err := args.EBClient.PutTargets(&eventbridge.PutTargetsInput{
+		Rule:    &task.Name,
+		Targets: []*eventbridge.Target{awsTarget},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to update targets for scheduled task rule %s", task.Name)
+	}
+
+	if *respPutTargets.FailedEntryCount > 0 {
+		for _, e := range respPutTargets.FailedEntries {
+			log.Printf("Failed to update entry: %v\n", *e)
+		}
+
+		return errors.Errorf("failed to update scheduled task entries: %s", task.Name)
+	}
+
+	return nil
+}

--- a/awsecs/awsevent.go
+++ b/awsecs/awsevent.go
@@ -74,7 +74,7 @@ func UpdateScheduledTask(args UpdateScheduledTaskArgs) error {
 		return errors.Wrapf(err, "failed to update targets for scheduled task rule %s", task.Name)
 	}
 
-	if *respPutTargets.FailedEntryCount > 0 {
+	if respPutTargets.FailedEntryCount != nil && *respPutTargets.FailedEntryCount > 0 {
 		for _, e := range respPutTargets.FailedEntries {
 			log.Printf("Failed to update entry: %v\n", *e)
 		}

--- a/awsecs/mock.go
+++ b/awsecs/mock.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface"
 )
 
 type mockService struct {
@@ -21,12 +23,12 @@ func (ms *mockService) TaskDefinitionArn() string {
 	return fmt.Sprintf("arn:aws:ecs:us-east-1:123456:task-definition/%s:%d", ms.name, ms.taskDefVersion)
 }
 
-type MockClient struct {
+type MockECSClient struct {
 	ecsiface.ECSAPI
 	services map[string]*mockService
 }
 
-func NewMockClient(serviceNames []string, imageName, gitsha string) *MockClient {
+func NewMockECSClient(serviceNames []string, imageName, gitsha string) *MockECSClient {
 	services := make(map[string]*mockService)
 
 	for _, s := range serviceNames {
@@ -39,12 +41,12 @@ func NewMockClient(serviceNames []string, imageName, gitsha string) *MockClient 
 		}
 	}
 
-	return &MockClient{
+	return &MockECSClient{
 		services: services,
 	}
 }
 
-func (mc *MockClient) SetServiceStatus(name, status string) {
+func (mc *MockECSClient) SetServiceStatus(name, status string) {
 	s, ok := mc.services[name]
 	if !ok {
 		panic(fmt.Sprintf("mock ECS service %s not found", name))
@@ -53,7 +55,7 @@ func (mc *MockClient) SetServiceStatus(name, status string) {
 	s.deploymentStatus = status
 }
 
-func (mc *MockClient) DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
+func (mc *MockECSClient) DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
 	outServices := make([]*ecs.Service, 0)
 	for _, serviceName := range input.Services {
 		s, ok := mc.services[*serviceName]
@@ -81,7 +83,7 @@ func (mc *MockClient) DescribeServices(input *ecs.DescribeServicesInput) (*ecs.D
 	}, nil
 }
 
-func (mc *MockClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+func (mc *MockECSClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
 	var service *mockService
 	for _, s := range mc.services {
 		if s.TaskDefinitionArn() == *input.TaskDefinition {
@@ -108,7 +110,7 @@ func (mc *MockClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionIn
 	}, nil
 }
 
-func (mc *MockClient) RegisterTaskDefinition(input *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
+func (mc *MockECSClient) RegisterTaskDefinition(input *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
 	service, ok := mc.services[*input.Family]
 	if !ok {
 		return nil, errors.New("Task definition family not found")
@@ -124,7 +126,7 @@ func (mc *MockClient) RegisterTaskDefinition(input *ecs.RegisterTaskDefinitionIn
 	}, nil
 }
 
-func (mc *MockClient) UpdateService(input *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
+func (mc *MockECSClient) UpdateService(input *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
 	_, ok := mc.services[*input.Service]
 	if !ok {
 		return nil, errors.New("Service not found")
@@ -132,4 +134,60 @@ func (mc *MockClient) UpdateService(input *ecs.UpdateServiceInput) (*ecs.UpdateS
 
 	// We don't actually use the return value
 	return &ecs.UpdateServiceOutput{}, nil
+}
+
+// Event Bridge mocks
+
+type mockScheduledTask struct {
+	name       string
+	taskDefARN string
+}
+
+type MockEventBridgeClient struct {
+	eventbridgeiface.EventBridgeAPI
+	tasks map[string]*mockScheduledTask
+}
+
+func NewMockEventBridgeClient(taskNames []string) *MockEventBridgeClient {
+	tasks := make(map[string]*mockScheduledTask)
+
+	for _, t := range taskNames {
+		tasks[t] = &mockScheduledTask{
+			name:       t,
+			taskDefARN: fmt.Sprintf("arn:aws:ecs:us-east-1:123456:task-definition/%s:1", t),
+		}
+	}
+
+	return &MockEventBridgeClient{
+		tasks: tasks,
+	}
+}
+
+func (mc *MockEventBridgeClient) ListTargetsByRule(input *eventbridge.ListTargetsByRuleInput) (*eventbridge.ListTargetsByRuleOutput, error) {
+	t, ok := mc.tasks[*input.Rule]
+	if !ok {
+		return nil, errors.New("Rule not found")
+	}
+
+	return &eventbridge.ListTargetsByRuleOutput{
+		Targets: []*eventbridge.Target{
+			{
+				EcsParameters: &eventbridge.EcsParameters{
+					TaskDefinitionArn: aws.String(t.taskDefARN),
+				},
+			},
+		},
+	}, nil
+}
+
+func (mc *MockEventBridgeClient) PutTargets(input *eventbridge.PutTargetsInput) (*eventbridge.PutTargetsOutput, error) {
+	t, ok := mc.tasks[*input.Rule]
+	if !ok {
+		return nil, errors.New("Rule not found")
+	}
+
+	t.taskDefARN = *input.Targets[0].EcsParameters.TaskDefinitionArn
+	return &eventbridge.PutTargetsOutput{
+		FailedEntryCount: aws.Int64(0),
+	}, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,24 +23,37 @@ func TestReadServices(t *testing.T) {
 			URL:     "https://staging.example.touchbistro.io/ping",
 		},
 	}
+	expectedScheduledTasks := []*config.ScheduledTask{
+		{
+			Name:   "weekly-job",
+			Gitsha: gitsha,
+		},
+		{
+			Name:   "monthly-job",
+			Gitsha: gitsha,
+		},
+	}
 
-	services, err := config.ReadServices("testdata/gehen.good.yml", gitsha)
+	services, scheduledTasks, err := config.Read("testdata/gehen.good.yml", gitsha)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expectedServices, services)
+	assert.ElementsMatch(t, expectedScheduledTasks, scheduledTasks)
 }
 
 func TestReadServicesInvalid(t *testing.T) {
 	gitsha := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
-	services, err := config.ReadServices("testdata/gehen.bad.yml", gitsha)
+	services, scheduledTasks, err := config.Read("testdata/gehen.bad.yml", gitsha)
 
 	assert.Error(t, err)
 	assert.Nil(t, services)
+	assert.Nil(t, scheduledTasks)
 }
 
 func TestNoGehenYaml(t *testing.T) {
-	services, err := config.ReadServices("testdata/gehen.notfound.yml", "")
+	services, scheduledTasks, err := config.Read("testdata/gehen.notfound.yml", "")
 
 	assert.Error(t, err)
 	assert.Nil(t, services)
+	assert.Nil(t, scheduledTasks)
 }

--- a/config/testdata/gehen.good.yml
+++ b/config/testdata/gehen.good.yml
@@ -5,3 +5,6 @@ services:
   example-staging:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster
     url: https://staging.example.touchbistro.io/ping
+scheduledTasks:
+  weekly-job:
+  monthly-job:

--- a/gehen.example.yml
+++ b/gehen.example.yml
@@ -5,3 +5,5 @@ services:
   example-staging:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster
     url: https://staging.example.touchbistro.io/ping
+scheduledTasks:
+  example-job:

--- a/main.go
+++ b/main.go
@@ -171,11 +171,9 @@ func performRollback(services []*config.Service, scheduledTasks []*config.Schedu
 	// Also they would have inconsitent versions
 	rollbackScheduledTaskResults := deploy.RollbackScheduledTasks(scheduledTasks, ebClient, ecsClient)
 	rollbackScheduledTasksFailed := false
-	succeededScheduledTasks := make([]*config.ScheduledTask, 0)
 
 	for _, result := range rollbackScheduledTaskResults {
 		if result.Err == nil {
-			succeededScheduledTasks = append(succeededScheduledTasks, result.Task)
 			continue
 		}
 
@@ -273,11 +271,9 @@ func main() {
 	// Update scheduled tasks first so if this fails we don't need to worry about rolling back services
 	updateScheduledTaskResults := deploy.UpdateScheduledTasks(scheduledTasks, ebClient, ecsClient)
 	updateScheduledTasksFailed := false
-	succeededScheduledTasks := make([]*config.ScheduledTask, 0)
 
 	for _, result := range updateScheduledTaskResults {
 		if result.Err == nil {
-			succeededScheduledTasks = append(succeededScheduledTasks, result.Task)
 			continue
 		}
 


### PR DESCRIPTION
Update the Task Definition used by a scheduled task so it uses the latest version of the service. Scheduled task updates are done first, that way if they failed we can just abort. If deploying ECS services fails, then we will roll back the scheduled tasks so they don't remain on the new version.