### PR TITLE
feat: Add ability to config whether current or latest task def is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ services: # A map of services
   <service-name>: # The name of the ECS service
     cluster: string # The ECS cluster the service is in
     url: string # The URL to use to check that the new version has been deployed
+    updateStrategy: current | latest # Which task definition revision should be used
 scheduledTasks: # A map of ECS scheduled tasks
   <scheduled-task-name>: # The name of the ECS scheduled task
 ```

--- a/awsecs/awsevent.go
+++ b/awsecs/awsevent.go
@@ -45,7 +45,7 @@ func UpdateScheduledTask(args UpdateScheduledTaskArgs) error {
 		// Create a new revision of the task def using the new git sha
 		taskDefARN := *awsTarget.EcsParameters.TaskDefinitionArn
 		log.Printf("Found current task definition: %s\n", taskDefARN)
-		updateTaskDefRes, err := updateTaskDef(taskDefARN, task.Gitsha, args.ECSClient)
+		updateTaskDefRes, err := updateTaskDef(taskDefARN, task.Gitsha, config.UpdateStrategyCurrent, args.ECSClient)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update task def for scheduled task: %s", task.Name)
 		}
@@ -59,7 +59,7 @@ func UpdateScheduledTask(args UpdateScheduledTaskArgs) error {
 
 		// Set dynamic task values
 		task.PreviousGitsha = updateTaskDefRes.previousGitsha
-		task.PreviousTaskDefinitionARN = updateTaskDefRes.previousTaskDefARN
+		task.PreviousTaskDefinitionARN = taskDefARN
 		task.TaskDefinitionARN = updateTaskDefRes.newTaskDefARN
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,16 +11,18 @@ func TestReadServicesWithRole(t *testing.T) {
 	gitsha := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 	expectedServices := []*config.Service{
 		{
-			Name:    "example-production",
-			Gitsha:  gitsha,
-			Cluster: "arn:aws:ecs:us-east-1:123456:cluster/prod-cluster",
-			URL:     "https://example.touchbistro.io/ping",
+			Name:           "example-production",
+			Gitsha:         gitsha,
+			Cluster:        "arn:aws:ecs:us-east-1:123456:cluster/prod-cluster",
+			URL:            "https://example.touchbistro.io/ping",
+			UpdateStrategy: config.UpdateStrategyLatest,
 		},
 		{
-			Name:    "example-staging",
-			Gitsha:  gitsha,
-			Cluster: "arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster",
-			URL:     "https://staging.example.touchbistro.io/ping",
+			Name:           "example-staging",
+			Gitsha:         gitsha,
+			Cluster:        "arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster",
+			URL:            "https://staging.example.touchbistro.io/ping",
+			UpdateStrategy: config.UpdateStrategyCurrent,
 		},
 	}
 	expectedScheduledTasks := []*config.ScheduledTask{
@@ -50,16 +52,18 @@ func TestReadServicesWithoutRole(t *testing.T) {
 	gitsha := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 	expectedServices := []*config.Service{
 		{
-			Name:    "example-production",
-			Gitsha:  gitsha,
-			Cluster: "arn:aws:ecs:us-east-1:123456:cluster/prod-cluster",
-			URL:     "https://example.touchbistro.io/ping",
+			Name:           "example-production",
+			Gitsha:         gitsha,
+			Cluster:        "arn:aws:ecs:us-east-1:123456:cluster/prod-cluster",
+			URL:            "https://example.touchbistro.io/ping",
+			UpdateStrategy: config.UpdateStrategyCurrent,
 		},
 		{
-			Name:    "example-staging",
-			Gitsha:  gitsha,
-			Cluster: "arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster",
-			URL:     "https://staging.example.touchbistro.io/ping",
+			Name:           "example-staging",
+			Gitsha:         gitsha,
+			Cluster:        "arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster",
+			URL:            "https://staging.example.touchbistro.io/ping",
+			UpdateStrategy: config.UpdateStrategyCurrent,
 		},
 	}
 	expectedScheduledTasks := []*config.ScheduledTask{

--- a/config/testdata/gehen.good.yml
+++ b/config/testdata/gehen.good.yml
@@ -4,6 +4,7 @@ services:
   example-production:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/prod-cluster
     url: https://example.touchbistro.io/ping
+    updateStrategy: latest
   example-staging:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster
     url: https://staging.example.touchbistro.io/ping

--- a/gehen.example.yml
+++ b/gehen.example.yml
@@ -4,8 +4,10 @@ services:
   example-production:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/prod-cluster
     url: https://example.touchbistro.io/ping
+    updateStrategy: current
   example-staging:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster
     url: https://staging.example.touchbistro.io/ping
+    updateStrategy: latest
 scheduledTasks:
   example-job:


### PR DESCRIPTION
Add `updateStrategy` to service config. This changes which task def revision the new revision is created from. There are two options:
* `current` (default) - Use the current task def revision that the ECS service is using
* `latest` - Use the latest task def revision

A new task def will no longer be created if the task def found by the method above has the same Git SHA in the image as the new one that was specified. This means that redeploys will no longer create new task def revisions.