### PR TITLE
feat: Make deploy and deploy check optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Gehen
+
 Gehen is a mininal version update aid for ECS services.
 It makes it easy to deploy updates to ECS services, waits for the cutover to complete, and recovers if the deployment fails.
 
 ![](docs/resources/gehen.jpg)
 
 ## How it works
+
 #### Deployment
+
 Gehen assumes that docker images are tagged with the Git SHA of the corresponding commit.
 This makes it easy to identify which version of the code is in a given image.
 
@@ -15,18 +18,23 @@ It will then update the ECS service to use the new task definition and trigger a
 **NOTE:** Gehen assumes the service already exists in ECS. It will not create services for you.
 
 #### Deploy Check
-Gehen will keep pinging your service to see if the new version has been deployed.
+
+Gehen can be configured to ping your service to see if the new version has been deployed.
 For this to work your service must send the [Server](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server) header with the format `*-GITSHA` where `GITSHA` is the Git SHA you provided to Gehen to update the service to. An example header is `Server: infrastructure-boilerplate-production-api-da39a3ee5e6b4b0d3255bfef95601890afd80709`.
+
+To enable this feature set the `url` field under your service's configuration to the appropriate ping URL.
 
 Gehen will keep hitting the URL provided for your services until it either sees the new Git SHA in the header, or times out. The default timeout duration is 5 minutes.
 
 #### Drain Check
+
 Once Gehen sees that the new version of the service has deployed it will wait for the old version(s) to drain.
 A service has drained when the old version is unreachable by the load balancer.
 Gehen also waits until the number of running tasks matches the expected amount of tasks in ECS.
 The default timeout duration is 5 minutes.
 
 #### Rollback
+
 If the deployment or deploy check steps fail, Gehen will automatically roll back the service to the previous version.
 It will then go through the same deploy check and drain check processes to ensure the roll back was successful.
 
@@ -56,6 +64,7 @@ services: # A map of services
     updateStrategy: current | latest # Which task definition revision should be used
 scheduledTasks: # A map of ECS scheduled tasks
   <scheduled-task-name>: # The name of the ECS scheduled task
+timeoutMinutes: int # How many minutes to wait for the deploy check and drain check
 ```
 
 An example config is provided in [gehen.example.yml](gehen.example.yml).

--- a/README.md
+++ b/README.md
@@ -57,17 +57,27 @@ Gehen is configured through a `gehen.yml` file. This contains the list of ECS se
 The schema is as follows:
 
 ```yaml
+updateStrategy: current | latest | none # Which task definition revision should be used
 services: # A map of services
   <service-name>: # The name of the ECS service
     cluster: string # The ECS cluster the service is in
     url: string # The URL to use to check that the new version has been deployed
-    updateStrategy: current | latest # Which task definition revision should be used
 scheduledTasks: # A map of ECS scheduled tasks
   <scheduled-task-name>: # The name of the ECS scheduled task
 timeoutMinutes: int # How many minutes to wait for the deploy check and drain check
 ```
 
 An example config is provided in [gehen.example.yml](gehen.example.yml).
+
+### `updateStrategy`
+
+This field determines how services are updated.
+
+The possible values are:
+
+- `current`: Create a new task definition based off the revision the service is currently using.
+- `latest`: Create a new task definition based off the latest revision available.
+- `none`: Disable updating services. This prevents Gehen from deploying a new version of the service.
 
 ## Contributing
 

--- a/awsecs/awsecs.go
+++ b/awsecs/awsecs.go
@@ -102,6 +102,9 @@ func CheckDrain(service *config.Service, ecsClient ecsiface.ECSAPI) (bool, error
 	for _, deployment := range awsService.Deployments {
 		expectedTaskDefARN := service.TaskDefinitionARN
 		if expectedTaskDefARN == "" {
+			// If no task def arn set for the service, fallback to the one present on AWS
+			// this should work since that is set by calls to UpdateService, so it should be
+			// the desired one for new deploys
 			expectedTaskDefARN = *awsService.TaskDefinition
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,12 +40,13 @@ func TestReadServicesWithRole(t *testing.T) {
 		ARN: "arn:aws:iam::123456:role/OrganizationAccountAccessRole",
 	}
 
-	services, scheduledTasks, role, err := config.Read("testdata/gehen.good.yml", gitsha)
+	parsedConfig, err := config.Read("testdata/gehen.good.yml", gitsha)
 
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, expectedServices, services)
-	assert.ElementsMatch(t, expectedScheduledTasks, scheduledTasks)
-	assert.Equal(t, expectedRole, role)
+	assert.ElementsMatch(t, expectedServices, parsedConfig.Services)
+	assert.ElementsMatch(t, expectedScheduledTasks, parsedConfig.ScheduledTasks)
+	assert.Equal(t, expectedRole, parsedConfig.Role)
+	assert.Equal(t, 5, parsedConfig.TimeoutMinutes)
 }
 
 func TestReadServicesWithoutRole(t *testing.T) {
@@ -77,29 +78,32 @@ func TestReadServicesWithoutRole(t *testing.T) {
 		},
 	}
 
-	services, scheduledTasks, role, err := config.Read("testdata/gehen.no-role.yml", gitsha)
+	parsedConfig, err := config.Read("testdata/gehen.no-role.yml", gitsha)
 
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, expectedServices, services)
-	assert.ElementsMatch(t, expectedScheduledTasks, scheduledTasks)
-	assert.Nil(t, role)
+	assert.ElementsMatch(t, expectedServices, parsedConfig.Services)
+	assert.ElementsMatch(t, expectedScheduledTasks, parsedConfig.ScheduledTasks)
+	assert.Nil(t, parsedConfig.Role)
+	assert.Equal(t, 0, parsedConfig.TimeoutMinutes)
 }
 
 func TestReadServicesInvalid(t *testing.T) {
 	gitsha := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
-	services, scheduledTasks, role, err := config.Read("testdata/gehen.bad.yml", gitsha)
+	parsedConfig, err := config.Read("testdata/gehen.bad.yml", gitsha)
 
 	assert.Error(t, err)
-	assert.Nil(t, services)
-	assert.Nil(t, scheduledTasks)
-	assert.Nil(t, role)
+	assert.Nil(t, parsedConfig.Services)
+	assert.Nil(t, parsedConfig.ScheduledTasks)
+	assert.Nil(t, parsedConfig.Role)
+	assert.Equal(t, 0, parsedConfig.TimeoutMinutes)
 }
 
 func TestNoGehenYaml(t *testing.T) {
-	services, scheduledTasks, role, err := config.Read("testdata/gehen.notfound.yml", "")
+	parsedConfig, err := config.Read("testdata/gehen.notfound.yml", "")
 
 	assert.Error(t, err)
-	assert.Nil(t, services)
-	assert.Nil(t, scheduledTasks)
-	assert.Nil(t, role)
+	assert.Nil(t, parsedConfig.Services)
+	assert.Nil(t, parsedConfig.ScheduledTasks)
+	assert.Nil(t, parsedConfig.Role)
+	assert.Equal(t, 0, parsedConfig.TimeoutMinutes)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestReadServicesWithRole(t *testing.T) {
 			Gitsha:         gitsha,
 			Cluster:        "arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster",
 			URL:            "https://staging.example.touchbistro.io/ping",
-			UpdateStrategy: config.UpdateStrategyCurrent,
+			UpdateStrategy: config.UpdateStrategyLatest,
 		},
 	}
 	expectedScheduledTasks := []*config.ScheduledTask{

--- a/config/testdata/gehen.good.yml
+++ b/config/testdata/gehen.good.yml
@@ -11,3 +11,4 @@ services:
 scheduledTasks:
   weekly-job:
   monthly-job:
+timeoutMinutes: 5

--- a/config/testdata/gehen.good.yml
+++ b/config/testdata/gehen.good.yml
@@ -4,7 +4,6 @@ services:
   example-production:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/prod-cluster
     url: https://example.touchbistro.io/ping
-    updateStrategy: latest
   example-staging:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster
     url: https://staging.example.touchbistro.io/ping
@@ -12,3 +11,4 @@ scheduledTasks:
   weekly-job:
   monthly-job:
 timeoutMinutes: 5
+updateStrategy: latest

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -108,6 +108,7 @@ func CheckDeployed(services []*config.Service) []Result {
 		go func(service *config.Service) {
 			// If service has no URL set, skip deploy check
 			if service.URL == "" {
+				log.Printf("Skipping deploy check for %s because no URL is set", color.Cyan(service.Name))
 				resultChan <- Result{service, ErrNoDeployCheckURL}
 				return
 			}

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -318,6 +318,45 @@ func TestCheckDeployFailed(t *testing.T) {
 	assert.ElementsMatch(t, expectedResults, results)
 }
 
+func TestCheckDeployedSkip(t *testing.T) {
+	deploy.TimeoutDuration(3 * time.Second)
+	deploy.CheckIntervalDuration(250 * time.Millisecond)
+
+	gitsha := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+	services := []*config.Service{
+		{
+			Name:   "example-production",
+			Gitsha: gitsha,
+		},
+		{
+			Name:   "example-staging",
+			Gitsha: gitsha,
+		},
+	}
+
+	expectedResults := []deploy.Result{
+		{
+			Service: &config.Service{
+				Name:   "example-production",
+				Gitsha: gitsha,
+			},
+			Err: deploy.ErrNoDeployCheckURL,
+		},
+		{
+			Service: &config.Service{
+				Name:   "example-staging",
+				Gitsha: gitsha,
+			},
+			Err: deploy.ErrNoDeployCheckURL,
+		},
+	}
+
+	results := deploy.CheckDeployed(services)
+
+	assert.ElementsMatch(t, expectedResults, results)
+}
+
 func TestCheckDrain(t *testing.T) {
 	deploy.TimeoutDuration(3 * time.Second)
 	deploy.CheckIntervalDuration(250 * time.Millisecond)

--- a/gehen.example.yml
+++ b/gehen.example.yml
@@ -11,3 +11,4 @@ services:
     updateStrategy: latest
 scheduledTasks:
   example-job:
+timeoutMinutes: 5

--- a/gehen.example.yml
+++ b/gehen.example.yml
@@ -4,11 +4,10 @@ services:
   example-production:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/prod-cluster
     url: https://example.touchbistro.io/ping
-    updateStrategy: current
   example-staging:
     cluster: arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster
     url: https://staging.example.touchbistro.io/ping
-    updateStrategy: latest
 scheduledTasks:
   example-job:
 timeoutMinutes: 5
+updateStrategy: current

--- a/main.go
+++ b/main.go
@@ -348,7 +348,7 @@ func main() {
 	checkDeployedFailed := false
 
 	for _, result := range checkDeployedResults {
-		if result.Err == nil {
+		if result.Err == nil || result.Err == deploy.ErrNoDeployCheckURL {
 			continue
 		}
 


### PR DESCRIPTION
* `url` field in service config is now optional. If it isn't set, then the deploy check step is skipped.
* `timeoutMinutes` field added to config to allow configuring how long gehen waits for deploy checks and drain checks before timing out.
* `updateStrategy` can now be given the value `none` which disables deployment. This will also disable rollbacks.

BREAKING CHANGES:
* `updateStrategy` is now a global field instead of per service.