### PR TITLE
Fix ClusterNotFoundException

### DIFF
--- a/awsecs/awsecs.go
+++ b/awsecs/awsecs.go
@@ -133,7 +133,8 @@ func CheckDrain(service *config.Service, ecsClient ecsiface.ECSAPI) (bool, error
 		return false, errors.Wrapf(err, "failed to list tasks for service: %s", service.Name)
 	}
 	respDescribeTasks, err := ecsClient.DescribeTasks(&ecs.DescribeTasksInput{
-		Tasks: respListTasks.TaskArns,
+		Cluster: &service.Cluster,
+		Tasks:   respListTasks.TaskArns,
 	})
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get tasks for service: %s", service.Name)

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -469,7 +469,7 @@ func TestCheckDrainFailed(t *testing.T) {
 		2,
 	)
 	mockClient.CreateMockTasks(
-		"arn:aws:ecs:us-east-1:123456:cluster/prod-cluster",
+		"arn:aws:ecs:us-east-1:123456:cluster/non-prod-cluster",
 		"example-staging",
 		"arn:aws:ecs:us-east-1:123456:task-definition/example-staging:1",
 		false,


### PR DESCRIPTION
`Cluster` is required for `DescribeTasks` and it was causing this error:
```
2021/04/01 02:46:21 Error: failed to get tasks for service: infrastructure-boilerplate-api-svc: ClusterNotFoundException: Cluster not found.
```